### PR TITLE
Normalize credit and capture API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='spreedly-sdk',
-    version='0.3.0',
+    version='0.3.1',
     author='aplazame',
     author_email='dev@aplazame.com',
     packages=['spreedly_sdk'],

--- a/spreedly_sdk/__init__.py
+++ b/spreedly_sdk/__init__.py
@@ -265,7 +265,7 @@ class Client(object):
             gateway_token, retain_on_success, payment_type='authorize', **kwargs)
 
     @_nested('transaction')
-    def capture(self,  amount, currency_code, transaction_token):
+    def capture(self, amount, currency_code, transaction_token):
         data = lb.E.transaction(
             lb.E.amount(str(amount)),
             lb.E.currency_code(currency_code))
@@ -280,11 +280,11 @@ class Client(object):
         return self.post("transactions/{}/void".format(transaction_token))
 
     @_nested('transaction')
-    def credit(self, transaction_token, amount=None):
-        if amount is not None:
-            data = lb.E.transaction(lb.E.amount(str(amount)))
-        else:
-            data = None
+    def credit(self, amount, currency_code, transaction_token):
+        data = lb.E.transaction(
+            lb.E.amount(str(amount)),
+            lb.E.currency_code(currency_code))
+
         return self.post("transactions/{}/credit".format(
             transaction_token), data=data)
 


### PR DESCRIPTION
@gonzalomcruz @jneight , he visto que en backend siempre pasamos el amount a credit, así que normalizo ambos.

De paso veo que el credit no tiene currency_code, pero en la API sale, por si acaso lo dejo ya puesto